### PR TITLE
Alignment options for furigana text

### DIFF
--- a/macro_furiganize.py
+++ b/macro_furiganize.py
@@ -75,6 +75,7 @@ def Furiganize(dummy=''):
             xWordCursor.setString(token.kanji)
             if token.reading is not None:
                 xWordCursor.setPropertyValue("RubyText", token.reading)
+                xWordCursor.setPropertyValue("RubyAdjust", 1)
             xWordCursor.goRight(len(token.kanji), False)
     return None
 

--- a/macro_furiganize.py
+++ b/macro_furiganize.py
@@ -15,6 +15,13 @@ enc = "utf-8"
 isWin = False
 isMac = False
 
+# Enumeration values for the adjustment of ruby text.
+LEFT = 0
+CENTER = 1
+RIGHT = 2
+BLOCK = 3
+INDENT_BLOCK = 4
+
 srcFields = ['Expression']
 dstFields = ['Reading']
 
@@ -75,7 +82,7 @@ def Furiganize(dummy=''):
             xWordCursor.setString(token.kanji)
             if token.reading is not None:
                 xWordCursor.setPropertyValue("RubyText", token.reading)
-                xWordCursor.setPropertyValue("RubyAdjust", 1)
+                xWordCursor.setPropertyValue("RubyAdjust", CENTER)
             xWordCursor.goRight(len(token.kanji), False)
     return None
 


### PR DESCRIPTION
I added options for the alignment of the furigana text, setting CENTER as the default choice.
More information about the **RubyAdjust** property here: https://api.libreoffice.org/docs/idl/ref/namespacecom_1_1sun_1_1star_1_1text.html#adf417fe4b45f486fe88af93ad0b59efb